### PR TITLE
[WIP] Raw transaction index (txid->rawtx)

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use app::App;
-use index::{compute_script_hash, TxInRow, TxOutRow, TxRow};
+use index::{compute_script_hash, TxInRow, TxOutRow, TxRow, RawTxRow};
 use mempool::Tracker;
 use metrics::Metrics;
 use serde_json::Value;
@@ -127,6 +127,12 @@ fn txrow_by_txid(store: &ReadStore, txid: &Sha256dHash) -> Option<TxRow> {
     let key = TxRow::filter_full(&txid);
     let value = store.get(&key)?;
     Some(TxRow::from_row(&Row { key, value }))
+}
+
+fn rawtxrow_by_txid(store: &ReadStore, txid: &Sha256dHash) -> Option<RawTxRow> {
+    let key = RawTxRow::filter_full(&txid);
+    let value = store.get(&key)?;
+    Some(RawTxRow::from_row(&Row { key, value }))
 }
 
 fn txrows_by_prefix(store: &ReadStore, txid_prefix: &HashPrefix) -> Vec<TxRow> {
@@ -348,7 +354,15 @@ impl Query {
         self.app.daemon().gettransaction(tx_hash, blockhash)
     }
 
+    pub fn txindex_load_txn(&self, txid: &Sha256dHash) -> Result<Transaction> {
+        self.tx_cache.get_or_else(txid, || {
+            let row = rawtxrow_by_txid(self.app.read_store(), txid).unwrap();
+            Ok(deserialize(&row.rawtx).or(Err("cannot parse tx"))?)
+        })
+    }
+
     // Public API for transaction retrieval (for Electrum RPC)
+    // Fetched from bitcoind, includes tx confirmation information (number of confirmations and block hash)
     pub fn get_transaction(&self, tx_hash: &Sha256dHash, verbose: bool) -> Result<Value> {
         let blockhash = self.lookup_confirmed_blockhash(tx_hash, /*block_height*/ None)?;
         self.app

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -270,8 +270,8 @@ fn handle_request(req: Request<Body>, query: &Arc<Query>, cache: &Arc<Mutex<LruC
                 .map_or(0u32, |el| el.parse().unwrap_or(0))
                 .max(0u32) as usize).min(block.txdata.len());
             let limit = query_params.get("limit")
-                .map_or(10u32,|el| el.parse().unwrap_or(10u32) )
-                .min(50u32) as usize;
+                .map_or(50000u32,|el| el.parse().unwrap_or(50000u32) )
+                .min(50000u32) as usize;
             let end = (start+limit).min(block.txdata.len());
             let block = Block { header: block.header, txdata: block.txdata[start..end].to_vec() };
 


### PR DESCRIPTION
Used for processing GET /tx/:txid requests, as well as for fetching the
prevout txs of inputs. Not used by electrs internally elsewhere or for the
Electrum server, which still fetch via the block height index and bitcoind.

This could be further optimized by batching reads, especially for the
prevout txs of the txs in a block.