### PR TITLE
Implement raw transaction store

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use app::App;
-use index::{compute_script_hash, TxInRow, TxOutRow, TxRow};
+use index::{compute_script_hash, TxInRow, TxOutRow, TxRow, RawTxRow};
 use mempool::Tracker;
 use metrics::Metrics;
 use serde_json::Value;
@@ -127,6 +127,12 @@ fn txrow_by_txid(store: &ReadStore, txid: &Sha256dHash) -> Option<TxRow> {
     let key = TxRow::filter_full(&txid);
     let value = store.get(&key)?;
     Some(TxRow::from_row(&Row { key, value }))
+}
+
+fn rawtxrow_by_txid(store: &ReadStore, txid: &Sha256dHash) -> Option<RawTxRow> {
+    let key = RawTxRow::filter_full(&txid);
+    let value = store.get(&key)?;
+    Some(RawTxRow::from_row(&Row { key, value }))
 }
 
 fn txrows_by_prefix(store: &ReadStore, txid_prefix: &HashPrefix) -> Vec<TxRow> {
@@ -348,7 +354,19 @@ impl Query {
         self.app.daemon().gettransaction(tx_hash, blockhash)
     }
 
+    // Read from txstore, fallback to reading from bitcoind rpc
+    pub fn txstore_get(&self, txid: &Sha256dHash) -> Result<Transaction> {
+        match rawtxrow_by_txid(self.app.read_store(), txid) {
+            Some(row) => Ok(deserialize(&row.rawtx).chain_err(|| "cannot parse tx")?),
+            None => {
+                debug!("missing tx {} in txstore, asking node", txid);
+                self.app.daemon().gettransaction(txid, self.lookup_confirmed_blockhash(txid, None)?)
+            }
+        }
+    }
+
     // Public API for transaction retrieval (for Electrum RPC)
+    // Fetched from bitcoind, includes tx confirmation information (number of confirmations and block hash)
     pub fn get_transaction(&self, tx_hash: &Sha256dHash, verbose: bool) -> Result<Value> {
         let blockhash = self.lookup_confirmed_blockhash(tx_hash, /*block_height*/ None)?;
         self.app


### PR DESCRIPTION
Add txid->rawtx store, using 't' as the database prefix,
and a query.txstore_get() method to fetch txs from it.

Used for processing GET /tx/:txid requests, as well as for fetching the
prevout txs of inputs. Not used by electrs internally elsewhere or for the
Electrum server, which still fetch via the block height index and bitcoind.

Information about the confirmation status of transactions was removed from
REST API responses, since it is volatile and cannot be determined from the
rawtx index alone. This will be reintroduced as a separate endpoint.