### PR TITLE
Don't return a prevblockhash for the genesis block (signet_e)

### DIFF
--- a/src/rest.rs
+++ b/src/rest.rs
@@ -30,7 +30,7 @@ struct BlockValue {
     size: u32,
     weight: u32,
     confirmations: Option<u32>,
-    previousblockhash: String,
+    previousblockhash: Option<String>,
 }
 
 impl From<SignetBlock> for BlockValue {
@@ -45,7 +45,8 @@ impl From<SignetBlock> for BlockValue {
             weight: weight as u32,
             id: block.header.bitcoin_hash().be_hex_string(),
             confirmations: None,
-            previousblockhash: block.header.prev_blockhash.be_hex_string(),
+            previousblockhash: if &block.header.prev_blockhash[..] != &[0u8;32][..] { Some(block.header.prev_blockhash.be_hex_string()) }
+                               else { None },
         }
     }
 }


### PR DESCRIPTION
Used to return "0000000..." as the prevblockhash, now returns a null.

(cherry picked from commit 22522e1ac74abdfdfef716f9988e80165e580130)